### PR TITLE
ignition_file, interpolation support

### DIFF
--- a/ignition/resource_ignition_file.go
+++ b/ignition/resource_ignition_file.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 
 	"github.com/coreos/ignition/config/types"
+	"github.com/hashicorp/hil"
+	"github.com/hashicorp/hil/ast"
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -41,6 +44,13 @@ func resourceFile() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
+						},
+						"vars": &schema.Schema{
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
 						},
 					},
 				},
@@ -119,47 +129,27 @@ func buildFile(d *schema.ResourceData, c *cache) (string, error) {
 		return "", fmt.Errorf("content or source options must be present")
 	}
 
-	var compression types.Compression
-	var source types.Url
-	var hash *types.Hash
+	var contents types.FileContents
 	var err error
 
 	if hasContent {
-		source, err = encodeDataURL(
-			d.Get("content.0.mime").(string),
-			d.Get("content.0.content").(string),
-		)
-
+		contents, err = calculateFileContentFromContent(d)
 		if err != nil {
 			return "", err
 		}
 	}
 
 	if hasSource {
-		source, err = buildURL(d.Get("source.0.source").(string))
+		contents, err = calculateFileContentFromSource(d)
 		if err != nil {
 			return "", err
 		}
-
-		compression = types.Compression(d.Get("source.0.compression").(string))
-		h, err := buildHash(d.Get("source.0.verification").(string))
-		if err != nil {
-			return "", err
-		}
-
-		hash = &h
 	}
 
 	return c.addFile(&types.File{
 		Filesystem: d.Get("filesystem").(string),
 		Path:       types.Path(d.Get("path").(string)),
-		Contents: types.FileContents{
-			Compression: compression,
-			Source:      source,
-			Verification: types.Verification{
-				Hash: hash,
-			},
-		},
+		Contents:   contents,
 		User: types.FileUser{
 			Id: d.Get("uid").(int),
 		},
@@ -175,4 +165,77 @@ func encodeDataURL(mime, content string) (types.Url, error) {
 	return buildURL(
 		fmt.Sprintf("data:%s;charset=utf-8;base64,%s", mime, base64),
 	)
+}
+
+func calculateFileContentFromContent(d *schema.ResourceData) (types.FileContents, error) {
+	var c types.FileContents
+	var err error
+
+	content, err := interpolate(
+		d.Get("content.0.content").(string),
+		d.Get("content.0.vars").(map[string]interface{}),
+	)
+
+	if err != nil {
+		return c, err
+	}
+
+	c.Source, err = encodeDataURL(
+		d.Get("content.0.mime").(string),
+		content,
+	)
+
+	return c, err
+}
+
+func calculateFileContentFromSource(d *schema.ResourceData) (types.FileContents, error) {
+	var c types.FileContents
+	var err error
+
+	c.Source, err = buildURL(d.Get("source.0.source").(string))
+	if err != nil {
+		return c, err
+	}
+
+	c.Compression = types.Compression(d.Get("source.0.compression").(string))
+	h, err := buildHash(d.Get("source.0.verification").(string))
+	if err != nil {
+		return c, err
+	}
+
+	c.Verification.Hash = &h
+	return c, nil
+}
+
+func interpolate(s string, vars map[string]interface{}) (string, error) {
+	tree, err := hil.Parse(s)
+	if err != nil {
+		return "", err
+	}
+
+	varmap := make(map[string]ast.Variable, len(vars))
+	for k, v := range vars {
+		varmap[k] = ast.Variable{
+			Value: v,
+			Type:  ast.TypeString,
+		}
+	}
+
+	config := hil.EvalConfig{
+		GlobalScope: &ast.BasicScope{
+			VarMap:  varmap,
+			FuncMap: config.Funcs(),
+		},
+	}
+
+	result, err := hil.Eval(tree, &config)
+	if err != nil {
+		return "", err
+	}
+
+	if result.Type != hil.TypeString {
+		return "", fmt.Errorf("unexpected output hil.Type: %v", result.Type)
+	}
+
+	return result.Value.(string), nil
 }

--- a/ignition/resource_ignition_file_test.go
+++ b/ignition/resource_ignition_file_test.go
@@ -20,6 +20,18 @@ func TestIngnitionFile(t *testing.T) {
 			gid = 84
 		}
 
+		data "ignition_file" "bar" {
+ 			filesystem = "bar"
+ 			path = "/bar"
+ 			content {
+ 				content = "bar $${bar} $${foo+10}"
+ 				vars {
+ 					bar = "foo"
+ 					foo = 32
+ 				}
+ 			}
+ 		}
+
 		data "ignition_file" "qux" {
 			filesystem = "qux"
 			path = "/qux"
@@ -33,11 +45,12 @@ func TestIngnitionFile(t *testing.T) {
 		data "ignition_config" "test" {
 			files = [
 				"${data.ignition_file.foo.id}",
+				"${data.ignition_file.bar.id}",
 				"${data.ignition_file.qux.id}",
 			]
 		}
 	`, func(c *types.Config) error {
-		if len(c.Storage.Files) != 2 {
+		if len(c.Storage.Files) != 3 {
 			return fmt.Errorf("arrays, found %d", len(c.Storage.Arrays))
 		}
 
@@ -67,6 +80,15 @@ func TestIngnitionFile(t *testing.T) {
 		}
 
 		f = c.Storage.Files[1]
+		if f.Filesystem != "bar" {
+			return fmt.Errorf("filesystem, found %q", f.Filesystem)
+		}
+
+		if f.Contents.Source.String() != "data:text/plain;charset=utf-8;base64,YmFyIGZvbyA0Mg==" {
+			return fmt.Errorf("contents.source, found %q", f.Contents.Source)
+		}
+
+		f = c.Storage.Files[2]
 		if f.Filesystem != "qux" {
 			return fmt.Errorf("filesystem, found %q", f.Filesystem)
 		}

--- a/website/docs/d/file.html.md
+++ b/website/docs/d/file.html.md
@@ -19,7 +19,10 @@ data "ignition_file" "hello" {
 	filesystem = "foo"
 	path = "/hello.txt"
 	content {
-		content = "Hello World!"
+		content = "Hello $${world}"
+		vars {
+			world = "World!"
+		}
 	}
 }
 ```
@@ -52,18 +55,19 @@ The following arguments are supported:
 
 	__Note__: `content` and `source` are mutually exclusive
 
-* `mode` - (Optional) The list of partitions and their configuration for 
-this particular disk..
+* `mode` - (Optional) The list of partitions and their configuration for this particular disk.
 
 * `uid` - (Optional) The user ID of the owner.
 
 * `gid` - (Optional) The group ID of the owner.
 
 The `content` block supports:
- 
+
 * `mime` - (Required) MIME format of the content (default _text/plain_).
 
 * `content` - (Required) Content of the file.
+
+* `vars` - (Optional) Variables for interpolation within the content. Note that variables must all be primitives. Direct references to lists or maps will cause a validation error.
 
 The `source` block supports:
 


### PR DESCRIPTION
The PR introduce support for interpolation as does the template provider to the `ignition_file` data resource. 

```tf
data "ignition_file" "bar" {
	filesystem = "bar"
	path = "/bar"
	content {
		content = "bar $${bar} $${foo+10}"
		vars {
			bar = "foo"
			foo = 32
		}
	}
}
```