### PR TITLE
Fixed issue with ignition_filesystem when empty options passed in

### DIFF
--- a/ignition/provider.go
+++ b/ignition/provider.go
@@ -190,6 +190,9 @@ func hash(s string) string {
 func castSliceInterface(i []interface{}) []string {
 	var o []string
 	for _, value := range i {
+		if value == nil {
+			continue
+		}
 		o = append(o, value.(string))
 	}
 

--- a/ignition/resource_ignition_filesystem_test.go
+++ b/ignition/resource_ignition_filesystem_test.go
@@ -43,16 +43,27 @@ func TestIngnitionFilesystem(t *testing.T) {
 			}
 		}
 
+		data "ignition_filesystem" "zaz" {
+			name = "zaz"
+			mount {
+				device = "/zaz"
+				format = "ext4"
+				create = true
+				options = [""]
+			}
+		}
+
 		data "ignition_config" "test" {
 			filesystems = [
 				"${data.ignition_filesystem.foo.id}",
 				"${data.ignition_filesystem.qux.id}",
 				"${data.ignition_filesystem.baz.id}",
 				"${data.ignition_filesystem.bar.id}",
+				"${data.ignition_filesystem.zaz.id}",
 			]
 		}
 	`, func(c *types.Config) error {
-		if len(c.Storage.Filesystems) != 4 {
+		if len(c.Storage.Filesystems) != 5 {
 			return fmt.Errorf("disks, found %d", len(c.Storage.Filesystems))
 		}
 


### PR DESCRIPTION
This PR fixes a panic that will occur when passing in an empty array to options when defining an ignition_filesystem. I updated the tests to verify this issue is resolved as well. You can trigger the panic with the following terraform script:

https://gist.github.com/chosenken/56ca0e36675f10abb472f6faad423e4b

Please let me know if you need anything else, or have questions. Thanks!

Note:  PR created in v0.9-maint branch on terraform repo:  https://github.com/hashicorp/terraform/pull/15495