### PR TITLE
Allow users to omit the optional verification hashes

### DIFF
--- a/ignition/resource_ignition_config.go
+++ b/ignition/resource_ignition_config.go
@@ -198,12 +198,14 @@ func buildConfigReference(raw map[string]interface{}) (*types.ConfigReference, e
 
 	r.Source = src
 
-	hash, err := buildHash(raw["verification"].(string))
-	if err != nil {
-		return nil, err
-	}
+	if raw["verification"].(string) != "" {
+		hash, err := buildHash(raw["verification"].(string))
+		if err != nil {
+			return nil, err
+		}
 
-	r.Verification.Hash = &hash
+		r.Verification.Hash = &hash
+	}
 
 	return r, nil
 }

--- a/ignition/resource_ignition_config_test.go
+++ b/ignition/resource_ignition_config_test.go
@@ -45,9 +45,9 @@ func TestIngnitionFileAppend(t *testing.T) {
 				verification = "sha512-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 			}
 
-		    append {
-		    	source = "foo"
-		    	verification = "sha512-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+			append {
+				source = "foo"
+				verification = "sha512-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 			}
 		}
 	`, func(c *types.Config) error {
@@ -100,8 +100,8 @@ func TestIngnitionFileAppendNoVerification(t *testing.T) {
 				source = "foo"
 			}
 
-		    append {
-		    	source = "foo"
+			append {
+				source = "foo"
 			}
 		}
 	`, func(c *types.Config) error {

--- a/ignition/resource_ignition_config_test.go
+++ b/ignition/resource_ignition_config_test.go
@@ -68,6 +68,60 @@ func TestIngnitionFileAppend(t *testing.T) {
 	})
 }
 
+func TestIngnitionFileReplaceNoVerification(t *testing.T) {
+	testIgnition(t, `
+		data "ignition_config" "test" {
+			replace {
+				source = "foo"
+			}
+		}
+	`, func(c *types.Config) error {
+		r := c.Ignition.Config.Replace
+		if r == nil {
+			return fmt.Errorf("unable to find replace config")
+		}
+
+		if r.Source.String() != "foo" {
+			return fmt.Errorf("config.replace.source, found %q", r.Source)
+		}
+
+		if r.Verification.Hash != nil {
+			return fmt.Errorf("verification hash should be nil")
+		}
+
+		return nil
+	})
+}
+
+func TestIngnitionFileAppendNoVerification(t *testing.T) {
+	testIgnition(t, `
+		data "ignition_config" "test" {
+			append {
+				source = "foo"
+			}
+
+		    append {
+		    	source = "foo"
+			}
+		}
+	`, func(c *types.Config) error {
+		a := c.Ignition.Config.Append
+		if len(a) != 2 {
+			return fmt.Errorf("unable to find append config, expected 2")
+		}
+
+		if a[0].Source.String() != "foo" {
+			return fmt.Errorf("config.replace.source, found %q", a[0].Source)
+		}
+
+		if a[0].Verification.Hash != nil {
+			return fmt.Errorf("verification hash should be nil")
+		}
+
+		return nil
+	})
+}
+
 func testIgnitionError(t *testing.T, input string, expectedErr *regexp.Regexp) {
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,

--- a/ignition/resource_ignition_file.go
+++ b/ignition/resource_ignition_file.go
@@ -142,13 +142,11 @@ func buildFile(d *schema.ResourceData, c *cache) (string, error) {
 		}
 
 		compression = types.Compression(d.Get("source.0.compression").(string))
-		verification := d.Get("source.0.verification").(string)
-		if verification != "" {
-			h, err := buildHash(verification)
+		if v, ok := d.GetOk("source.0.verification"); ok {
+			h, err := buildHash(v.(string))
 			if err != nil {
 				return "", err
 			}
-
 			hash = &h
 		}
 	}

--- a/ignition/resource_ignition_file.go
+++ b/ignition/resource_ignition_file.go
@@ -142,12 +142,15 @@ func buildFile(d *schema.ResourceData, c *cache) (string, error) {
 		}
 
 		compression = types.Compression(d.Get("source.0.compression").(string))
-		h, err := buildHash(d.Get("source.0.verification").(string))
-		if err != nil {
-			return "", err
-		}
+		verification := d.Get("source.0.verification").(string)
+		if verification != "" {
+			h, err := buildHash(verification)
+			if err != nil {
+				return "", err
+			}
 
-		hash = &h
+			hash = &h
+		}
 	}
 
 	return c.addFile(&types.File{

--- a/ignition/resource_ignition_file_test.go
+++ b/ignition/resource_ignition_file_test.go
@@ -30,15 +30,25 @@ func TestIngnitionFile(t *testing.T) {
 			}
 		}
 
+		data "ignition_file" "nop" {
+			filesystem = "nop"
+			path = "/nop"
+			source {
+				source = "nop"
+				compression = "gzip"
+			}
+		}
+
 		data "ignition_config" "test" {
 			files = [
 				"${data.ignition_file.foo.id}",
 				"${data.ignition_file.qux.id}",
+				"${data.ignition_file.nop.id}",
 			]
 		}
 	`, func(c *types.Config) error {
-		if len(c.Storage.Files) != 2 {
-			return fmt.Errorf("arrays, found %d", len(c.Storage.Arrays))
+		if len(c.Storage.Files) != 3 {
+			return fmt.Errorf("arrays, found %d", len(c.Storage.Files))
 		}
 
 		f := c.Storage.Files[0]
@@ -85,6 +95,27 @@ func TestIngnitionFile(t *testing.T) {
 
 		if f.Contents.Verification.Hash.Sum != "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" {
 			return fmt.Errorf("config.replace.verification, found %q", f.Contents.Verification.Hash)
+		}
+
+		f = c.Storage.Files[2]
+		if f.Filesystem != "nop" {
+			return fmt.Errorf("filesystem, found %q", f.Filesystem)
+		}
+
+		if f.Path != "/nop" {
+			return fmt.Errorf("path, found %q", f.Path)
+		}
+
+		if f.Contents.Source.String() != "nop" {
+			return fmt.Errorf("contents.source, found %q", f.Contents.Source)
+		}
+
+		if f.Contents.Compression != "gzip" {
+			return fmt.Errorf("contents.compression, found %q", f.Contents.Compression)
+		}
+
+		if f.Contents.Verification.Hash != nil {
+			return fmt.Errorf("contents.verification should be nil, found %q", f.Contents.Verification.Hash)
 		}
 
 		return nil


### PR DESCRIPTION
As described in the configuration spec `verification` is optional for files and configuration append/replace sources.

This PR does only push the `Hash` back into the ignition configuration if the verification option was set in the terraform configuration. That way the config validation does not throw `malformed hash specifier` errors if one would omit the verification option.