### PR TITLE
systemd_unit v2 enabled documentation

### DIFF
--- a/website/docs/d/systemd_unit.html.md
+++ b/website/docs/d/systemd_unit.html.md
@@ -25,7 +25,7 @@ The following arguments are supported:
 
 * `name` - (Required) Tthe name of the unit. This must be suffixed with a valid unit type (e.g. _thing.service_).
 
-* `enable` - (Optional) Whether or not the service shall be enabled. When true, the service is enabled. In order for this to have any effect, the unit must have an install section. (default true)
+* `enabled` - (Optional) Whether or not the service shall be enabled. When true, the service is enabled. In order for this to have any effect, the unit must have an install section. (default true)
 
 * `mask` - (Optional) Whether or not the service shall be masked. When true, the service is masked by symlinking it to _/dev/null_.
 


### PR DESCRIPTION
Documentation said to use "enable" but this was changed to "enabled" as of 9a7bb1a23b4ae416db3287114124fdcd65cd9e61

This updates the systemd documentation to reflect this change. 

This resolves #17 