### PR TITLE
Document all supported schemes for config source

### DIFF
--- a/website/docs/d/config.html.md
+++ b/website/docs/d/config.html.md
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 The `append` and `replace` blocks supports:
 
-* `source` - (Required) The URL of the config. Supported schemes are http. Note: When using http, it is advisable to use the verification option to ensure the contents haven’t been modified.
+* `source` - (Required) The URL of the config. Supported schemes are http, https, tftp, s3, and data. When using http, it is advisable to use the verification option to ensure the contents haven't been modified.
 
 * `verification` - (Optional) The hash of the config, in the form _\<type\>-\<value\>_ where type is sha512.
 


### PR DESCRIPTION
The docs currently specify only http as a valid protocol for config append/replace sources.

The specification for ignition v2.1.0 specify that http, https, s3, tftp, and data are all valid (https://coreos.com/ignition/docs/latest/configuration-v2_1.html)

I'm assuming this compatibility is just missing from the provider docs, as it's part of the other data sources and I've got it working with s3 at least.

Thanks,
Alex