### PR TITLE
Updated directory mode readme

### DIFF
--- a/website/docs/d/directory.html.md
+++ b/website/docs/d/directory.html.md
@@ -27,7 +27,7 @@ The following arguments are supported:
 
 * `path` - (Required) The absolute path to the directory.
 
-* `mode` - (Optional) The directory's permission mode. Note that the mode must be properly specified as a decimal value (i.e. 0755 -> 493) or an octal value(i.e 0755).
+* `mode` - (Optional) The directory's permission mode. Note that the mode can be specified as a decimal value (i.e. 0755 -> 493) or an octal value(i.e 0755).
 
 * `uid` - (Optional) The user ID of the owner.
 

--- a/website/docs/d/directory.html.md
+++ b/website/docs/d/directory.html.md
@@ -27,7 +27,7 @@ The following arguments are supported:
 
 * `path` - (Required) The absolute path to the directory.
 
-* `mode` - (Optional) The directory's permission mode. Note that the mode must be properly specified as a decimal value (i.e. 0755 -> 493).
+* `mode` - (Optional) The directory's permission mode. Note that the mode must be properly specified as a decimal value (i.e. 0755 -> 493) or an octal value(i.e 0755).
 
 * `uid` - (Optional) The user ID of the owner.
 


### PR DESCRIPTION
Directories currently take both octal and decimal

Reference:
https://github.com/terraform-providers/terraform-provider-ignition/blob/master/ignition/resource_ignition_directory.go#L73
https://github.com/coreos/ignition/blob/master/config/v2_1/types/mode.go#L21