### PR TITLE
Remove cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,6 @@ module github.com/terraform-providers/terraform-provider-ignition
 require (
 	github.com/coreos/ignition v0.0.0-20170904171445-ea573e121f72
 	github.com/hashicorp/terraform v0.12.0
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/terraform-providers/terraform-provider-ignition
 require (
 	github.com/coreos/ignition v0.0.0-20170904171445-ea573e121f72
 	github.com/hashicorp/terraform v0.12.0
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/packer-community/winrmcp v0.0.0-20180102160824-81144009af58/go.mod h1
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pkg/errors v0.0.0-20170505043639-c605e284fe17 h1:chPfVn+gpAM5CTpTyVU9j8J+xgRGwmoDlNDLjKnJiYo=
 github.com/pkg/errors v0.0.0-20170505043639-c605e284fe17/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/ignition/provider.go
+++ b/ignition/provider.go
@@ -6,30 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"sync"
 
-	"github.com/coreos/ignition/config/v2_1/types"
 	"github.com/coreos/ignition/config/validate/report"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
-
-// globalCache keeps the instances of the internal types of ignition generated
-// by the different data resources with the goal to be reused by the
-// ignition_config data resource. The key of the maps are a hash of the types
-// calculated on the type serialized to JSON.
-var globalCache = &cache{
-	disks:         make(map[string]*types.Disk, 0),
-	arrays:        make(map[string]*types.Raid, 0),
-	filesystems:   make(map[string]*types.Filesystem, 0),
-	files:         make(map[string]*types.File, 0),
-	directories:   make(map[string]*types.Directory, 0),
-	links:         make(map[string]*types.Link, 0),
-	systemdUnits:  make(map[string]*types.Unit, 0),
-	networkdUnits: make(map[string]*types.Networkdunit, 0),
-	users:         make(map[string]*types.PasswdUser, 0),
-	groups:        make(map[string]*types.PasswdGroup, 0),
-}
 
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
@@ -47,121 +28,6 @@ func Provider() terraform.ResourceProvider {
 			"ignition_group":         dataSourceGroup(),
 		},
 	}
-}
-
-type cache struct {
-	disks         map[string]*types.Disk
-	arrays        map[string]*types.Raid
-	filesystems   map[string]*types.Filesystem
-	files         map[string]*types.File
-	directories   map[string]*types.Directory
-	links         map[string]*types.Link
-	systemdUnits  map[string]*types.Unit
-	networkdUnits map[string]*types.Networkdunit
-	users         map[string]*types.PasswdUser
-	groups        map[string]*types.PasswdGroup
-
-	sync.Mutex
-}
-
-func (c *cache) addDisk(g *types.Disk) string {
-	c.Lock()
-	defer c.Unlock()
-
-	id := id(g)
-	c.disks[id] = g
-
-	return id
-}
-
-func (c *cache) addRaid(r *types.Raid) string {
-	c.Lock()
-	defer c.Unlock()
-
-	id := id(r)
-	c.arrays[id] = r
-
-	return id
-}
-
-func (c *cache) addFilesystem(f *types.Filesystem) string {
-	c.Lock()
-	defer c.Unlock()
-
-	id := id(f)
-	c.filesystems[id] = f
-
-	return id
-}
-
-func (c *cache) addFile(f *types.File) string {
-	c.Lock()
-	defer c.Unlock()
-
-	id := id(f)
-	c.files[id] = f
-
-	return id
-}
-
-func (c *cache) addDirectory(d *types.Directory) string {
-	c.Lock()
-	defer c.Unlock()
-
-	id := id(d)
-	c.directories[id] = d
-
-	return id
-}
-
-func (c *cache) addLink(l *types.Link) string {
-	c.Lock()
-	defer c.Unlock()
-
-	id := id(l)
-	c.links[id] = l
-
-	return id
-}
-
-func (c *cache) addSystemdUnit(u *types.Unit) string {
-	c.Lock()
-	defer c.Unlock()
-
-	id := id(u)
-	c.systemdUnits[id] = u
-
-	return id
-}
-
-func (c *cache) addNetworkdUnit(u *types.Networkdunit) string {
-	c.Lock()
-	defer c.Unlock()
-
-	id := id(u)
-	c.networkdUnits[id] = u
-
-	return id
-}
-
-func (c *cache) addUser(u *types.PasswdUser) string {
-	c.Lock()
-	defer c.Unlock()
-
-	id := id(u)
-	c.users[id] = u
-
-	return id
-}
-
-func (c *cache) addGroup(g *types.PasswdGroup) string {
-	c.Lock()
-	defer c.Unlock()
-
-	id := id(g)
-	c.groups[id] = g
-
-	return id
 }
 
 func id(input interface{}) string {

--- a/ignition/provider.go
+++ b/ignition/provider.go
@@ -40,19 +40,6 @@ func hash(s string) string {
 	return hex.EncodeToString(sha[:])
 }
 
-func castSliceInterface(i []interface{}) []string {
-	var o []string
-	for _, value := range i {
-		if value == nil {
-			continue
-		}
-
-		o = append(o, value.(string))
-	}
-
-	return o
-}
-
 func getInt(d *schema.ResourceData, key string) *int {
 	var i *int
 	if value, ok := d.GetOk(key); ok {

--- a/ignition/resource_ignition_config.go
+++ b/ignition/resource_ignition_config.go
@@ -3,6 +3,8 @@ package ignition
 import (
 	"encoding/json"
 
+	"github.com/pkg/errors"
+
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/coreos/ignition/config/v2_1/types"
@@ -220,7 +222,7 @@ func buildStorage(d *schema.ResourceData) (types.Storage, error) {
 		d := types.Disk{}
 		err := json.Unmarshal([]byte(disk.(string)), &d)
 		if err != nil {
-			return storage, err
+			return storage, errors.Wrap(err, "No valid JSON found, make sure you're using .rendered and not .id")
 		}
 
 		storage.Disks = append(storage.Disks, d)
@@ -234,7 +236,7 @@ func buildStorage(d *schema.ResourceData) (types.Storage, error) {
 		a := types.Raid{}
 		err := json.Unmarshal([]byte(array.(string)), &a)
 		if err != nil {
-			return storage, err
+			return storage, errors.Wrap(err, "No valid JSON found, make sure you're using .rendered and not .id")
 		}
 
 		storage.Raid = append(storage.Raid, a)
@@ -248,7 +250,7 @@ func buildStorage(d *schema.ResourceData) (types.Storage, error) {
 		f := types.Filesystem{}
 		err := json.Unmarshal([]byte(fs.(string)), &f)
 		if err != nil {
-			return storage, err
+			return storage, errors.Wrap(err, "No valid JSON found, make sure you're using .rendered and not .id")
 		}
 
 		storage.Filesystems = append(storage.Filesystems, f)
@@ -262,7 +264,7 @@ func buildStorage(d *schema.ResourceData) (types.Storage, error) {
 		f := types.File{}
 		err := json.Unmarshal([]byte(file.(string)), &f)
 		if err != nil {
-			return storage, err
+			return storage, errors.Wrap(err, "No valid JSON found, make sure you're using .rendered and not .id")
 		}
 
 		storage.Files = append(storage.Files, f)
@@ -276,7 +278,7 @@ func buildStorage(d *schema.ResourceData) (types.Storage, error) {
 		f := types.Directory{}
 		err := json.Unmarshal([]byte(dir.(string)), &f)
 		if err != nil {
-			return storage, err
+			return storage, errors.Wrap(err, "No valid JSON found, make sure you're using .rendered and not .id")
 		}
 
 		storage.Directories = append(storage.Directories, f)
@@ -290,7 +292,7 @@ func buildStorage(d *schema.ResourceData) (types.Storage, error) {
 		f := types.Link{}
 		err := json.Unmarshal([]byte(link.(string)), &f)
 		if err != nil {
-			return storage, err
+			return storage, errors.Wrap(err, "No valid JSON found, make sure you're using .rendered and not .id")
 		}
 
 		storage.Links = append(storage.Links, f)
@@ -311,7 +313,7 @@ func buildSystemd(d *schema.ResourceData) (types.Systemd, error) {
 		u := types.Unit{}
 		err := json.Unmarshal([]byte(unit.(string)), &u)
 		if err != nil {
-			return systemd, err
+			return systemd, errors.Wrap(err, "No valid JSON found, make sure you're using .rendered and not .id")
 		}
 
 		systemd.Units = append(systemd.Units, u)
@@ -332,7 +334,7 @@ func buildNetworkd(d *schema.ResourceData) (types.Networkd, error) {
 		u := types.Networkdunit{}
 		err := json.Unmarshal([]byte(unit.(string)), &u)
 		if err != nil {
-			return networkd, err
+			return networkd, errors.Wrap(err, "No valid JSON found, make sure you're using .rendered and not .id")
 		}
 
 		networkd.Units = append(networkd.Units, u)
@@ -352,7 +354,7 @@ func buildPasswd(d *schema.ResourceData) (types.Passwd, error) {
 		u := types.PasswdUser{}
 		err := json.Unmarshal([]byte(user.(string)), &u)
 		if err != nil {
-			return passwd, err
+			return passwd, errors.Wrap(err, "No valid JSON found, make sure you're using .rendered and not .id")
 		}
 
 		passwd.Users = append(passwd.Users, u)
@@ -366,7 +368,7 @@ func buildPasswd(d *schema.ResourceData) (types.Passwd, error) {
 		g := types.PasswdGroup{}
 		err := json.Unmarshal([]byte(group.(string)), &g)
 		if err != nil {
-			return passwd, err
+			return passwd, errors.Wrap(err, "No valid JSON found, make sure you're using .rendered and not .id")
 		}
 
 		passwd.Groups = append(passwd.Groups, g)

--- a/ignition/resource_ignition_config.go
+++ b/ignition/resource_ignition_config.go
@@ -2,7 +2,6 @@ package ignition
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
@@ -101,7 +100,7 @@ func dataSourceConfig() *schema.Resource {
 }
 
 func resourceIgnitionFileRead(d *schema.ResourceData, meta interface{}) error {
-	rendered, err := renderConfig(d, globalCache)
+	rendered, err := renderConfig(d)
 	if err != nil {
 		return err
 	}
@@ -115,7 +114,7 @@ func resourceIgnitionFileRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceIgnitionFileExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	rendered, err := renderConfig(d, globalCache)
+	rendered, err := renderConfig(d)
 	if err != nil {
 		return false, err
 	}
@@ -123,8 +122,8 @@ func resourceIgnitionFileExists(d *schema.ResourceData, meta interface{}) (bool,
 	return hash(rendered) == d.Id(), nil
 }
 
-func renderConfig(d *schema.ResourceData, c *cache) (string, error) {
-	i, err := buildConfig(d, c)
+func renderConfig(d *schema.ResourceData) (string, error) {
+	i, err := buildConfig(d)
 	if err != nil {
 		return "", err
 	}
@@ -138,7 +137,7 @@ func renderConfig(d *schema.ResourceData, c *cache) (string, error) {
 	return string(bytes), nil
 }
 
-func buildConfig(d *schema.ResourceData, c *cache) (*types.Config, error) {
+func buildConfig(d *schema.ResourceData) (*types.Config, error) {
 	var err error
 	config := &types.Config{}
 	config.Ignition, err = buildIgnition(d)
@@ -146,22 +145,22 @@ func buildConfig(d *schema.ResourceData, c *cache) (*types.Config, error) {
 		return nil, err
 	}
 
-	config.Storage, err = buildStorage(d, c)
+	config.Storage, err = buildStorage(d)
 	if err != nil {
 		return nil, err
 	}
 
-	config.Systemd, err = buildSystemd(d, c)
+	config.Systemd, err = buildSystemd(d)
 	if err != nil {
 		return nil, err
 	}
 
-	config.Networkd, err = buildNetworkd(d, c)
+	config.Networkd, err = buildNetworkd(d)
 	if err != nil {
 		return nil, err
 	}
 
-	config.Passwd, err = buildPasswd(d, c)
+	config.Passwd, err = buildPasswd(d)
 	if err != nil {
 		return nil, err
 	}
@@ -210,151 +209,167 @@ func buildConfigReference(raw map[string]interface{}) (*types.ConfigReference, e
 	return r, nil
 }
 
-func buildStorage(d *schema.ResourceData, c *cache) (types.Storage, error) {
+func buildStorage(d *schema.ResourceData) (types.Storage, error) {
 	storage := types.Storage{}
 
-	for _, id := range d.Get("disks").([]interface{}) {
-		if id == nil {
+	for _, disk := range d.Get("disks").([]interface{}) {
+		if disk == nil {
 			continue
 		}
-		d, ok := c.disks[id.(string)]
-		if !ok {
-			return storage, fmt.Errorf("invalid disk %q, unknown disk id", id)
+
+		d := types.Disk{}
+		err := json.Unmarshal([]byte(disk.(string)), &d)
+		if err != nil {
+			return storage, err
 		}
 
-		storage.Disks = append(storage.Disks, *d)
+		storage.Disks = append(storage.Disks, d)
 	}
 
-	for _, id := range d.Get("arrays").([]interface{}) {
-		if id == nil {
+	for _, array := range d.Get("arrays").([]interface{}) {
+		if array == nil {
 			continue
 		}
-		a, ok := c.arrays[id.(string)]
-		if !ok {
-			return storage, fmt.Errorf("invalid raid %q, unknown raid id", id)
+
+		a := types.Raid{}
+		err := json.Unmarshal([]byte(array.(string)), &a)
+		if err != nil {
+			return storage, err
 		}
 
-		storage.Raid = append(storage.Raid, *a)
+		storage.Raid = append(storage.Raid, a)
 	}
 
-	for _, id := range d.Get("filesystems").([]interface{}) {
-		if id == nil {
+	for _, fs := range d.Get("filesystems").([]interface{}) {
+		if fs == nil {
 			continue
 		}
-		f, ok := c.filesystems[id.(string)]
-		if !ok {
-			return storage, fmt.Errorf("invalid filesystem %q, unknown filesystem id", id)
+
+		f := types.Filesystem{}
+		err := json.Unmarshal([]byte(fs.(string)), &f)
+		if err != nil {
+			return storage, err
 		}
 
-		storage.Filesystems = append(storage.Filesystems, *f)
+		storage.Filesystems = append(storage.Filesystems, f)
 	}
 
-	for _, id := range d.Get("files").([]interface{}) {
-		if id == nil {
+	for _, file := range d.Get("files").([]interface{}) {
+		if file == nil {
 			continue
 		}
-		f, ok := c.files[id.(string)]
-		if !ok {
-			return storage, fmt.Errorf("invalid file %q, unknown file id", id)
+
+		f := types.File{}
+		err := json.Unmarshal([]byte(file.(string)), &f)
+		if err != nil {
+			return storage, err
 		}
 
-		storage.Files = append(storage.Files, *f)
+		storage.Files = append(storage.Files, f)
 	}
 
-	for _, id := range d.Get("directories").([]interface{}) {
-		if id == nil {
+	for _, dir := range d.Get("directories").([]interface{}) {
+		if dir == nil {
 			continue
 		}
-		f, ok := c.directories[id.(string)]
-		if !ok {
-			return storage, fmt.Errorf("invalid file %q, unknown directory id", id)
+
+		f := types.Directory{}
+		err := json.Unmarshal([]byte(dir.(string)), &f)
+		if err != nil {
+			return storage, err
 		}
 
-		storage.Directories = append(storage.Directories, *f)
+		storage.Directories = append(storage.Directories, f)
 	}
 
-	for _, id := range d.Get("links").([]interface{}) {
-		if id == nil {
+	for _, link := range d.Get("links").([]interface{}) {
+		if link == nil {
 			continue
 		}
-		f, ok := c.links[id.(string)]
-		if !ok {
-			return storage, fmt.Errorf("invalid file %q, unknown link id", id)
+
+		f := types.Link{}
+		err := json.Unmarshal([]byte(link.(string)), &f)
+		if err != nil {
+			return storage, err
 		}
 
-		storage.Links = append(storage.Links, *f)
+		storage.Links = append(storage.Links, f)
 	}
 
 	return storage, nil
 
 }
 
-func buildSystemd(d *schema.ResourceData, c *cache) (types.Systemd, error) {
+func buildSystemd(d *schema.ResourceData) (types.Systemd, error) {
 	systemd := types.Systemd{}
 
-	for _, id := range d.Get("systemd").([]interface{}) {
-		if id == nil {
+	for _, unit := range d.Get("systemd").([]interface{}) {
+		if unit == nil {
 			continue
 		}
 
-		u, ok := c.systemdUnits[id.(string)]
-		if !ok {
-			return systemd, fmt.Errorf("invalid systemd unit %q, unknown systemd unit id", id)
+		u := types.Unit{}
+		err := json.Unmarshal([]byte(unit.(string)), &u)
+		if err != nil {
+			return systemd, err
 		}
 
-		systemd.Units = append(systemd.Units, *u)
+		systemd.Units = append(systemd.Units, u)
 	}
 
 	return systemd, nil
 
 }
 
-func buildNetworkd(d *schema.ResourceData, c *cache) (types.Networkd, error) {
+func buildNetworkd(d *schema.ResourceData) (types.Networkd, error) {
 	networkd := types.Networkd{}
 
-	for _, id := range d.Get("networkd").([]interface{}) {
-		if id == nil {
+	for _, unit := range d.Get("networkd").([]interface{}) {
+		if unit == nil {
 			continue
 		}
 
-		u, ok := c.networkdUnits[id.(string)]
-		if !ok {
-			return networkd, fmt.Errorf("invalid networkd unit %q, unknown networkd unit id", id)
+		u := types.Networkdunit{}
+		err := json.Unmarshal([]byte(unit.(string)), &u)
+		if err != nil {
+			return networkd, err
 		}
 
-		networkd.Units = append(networkd.Units, *u)
+		networkd.Units = append(networkd.Units, u)
 	}
 
 	return networkd, nil
 }
 
-func buildPasswd(d *schema.ResourceData, c *cache) (types.Passwd, error) {
+func buildPasswd(d *schema.ResourceData) (types.Passwd, error) {
 	passwd := types.Passwd{}
 
-	for _, id := range d.Get("users").([]interface{}) {
-		if id == nil {
+	for _, user := range d.Get("users").([]interface{}) {
+		if user == nil {
 			continue
 		}
 
-		u, ok := c.users[id.(string)]
-		if !ok {
-			return passwd, fmt.Errorf("invalid user %q, unknown user id", id)
+		u := types.PasswdUser{}
+		err := json.Unmarshal([]byte(user.(string)), &u)
+		if err != nil {
+			return passwd, err
 		}
 
-		passwd.Users = append(passwd.Users, *u)
+		passwd.Users = append(passwd.Users, u)
 	}
 
-	for _, id := range d.Get("groups").([]interface{}) {
-		if id == nil {
+	for _, group := range d.Get("groups").([]interface{}) {
+		if group == nil {
 			continue
 		}
 
-		g, ok := c.groups[id.(string)]
-		if !ok {
-			return passwd, fmt.Errorf("invalid group %q, unknown group id", id)
+		g := types.PasswdGroup{}
+		err := json.Unmarshal([]byte(group.(string)), &g)
+		if err != nil {
+			return passwd, err
 		}
 
-		passwd.Groups = append(passwd.Groups, *g)
+		passwd.Groups = append(passwd.Groups, g)
 	}
 
 	return passwd, nil

--- a/ignition/resource_ignition_config_test.go
+++ b/ignition/resource_ignition_config_test.go
@@ -124,7 +124,7 @@ func TestIngnitionFileAppendNoVerification(t *testing.T) {
 
 func TestIgnitionConfigDisks(t *testing.T) {
 	testIgnition(t, `
-	variable "ignition_disk_ids" {
+	variable "ignition_disk_renders" {
 		type = "list"
 		default = [""]
 	}
@@ -138,8 +138,8 @@ func TestIgnitionConfigDisks(t *testing.T) {
 	 }
 
 	data "ignition_config" "test" {
-		disks = concat([data.ignition_disk.test.id],
-			var.ignition_disk_ids)
+		disks = concat([data.ignition_disk.test.rendered],
+			var.ignition_disk_renders)
 	}
 	`, func(c *types.Config) error {
 		f := c.Storage.Disks[0]
@@ -152,7 +152,7 @@ func TestIgnitionConfigDisks(t *testing.T) {
 
 func TestIgnitionConfigArrays(t *testing.T) {
 	testIgnition(t, `
-	variable "ignition_array_ids" {
+	variable "ignition_array_renders" {
 		type = "list"
 		default = [""]
 	}
@@ -167,8 +167,8 @@ func TestIgnitionConfigArrays(t *testing.T) {
 	}
 
 	data "ignition_config" "test" {
-		arrays = concat([data.ignition_raid.md.id],
-			var.ignition_array_ids)
+		arrays = concat([data.ignition_raid.md.rendered],
+			var.ignition_array_renders)
 	}
 	`, func(c *types.Config) error {
 		f := c.Storage.Raid[0]
@@ -181,7 +181,7 @@ func TestIgnitionConfigArrays(t *testing.T) {
 
 func TestIgnitionConfigFilesystems(t *testing.T) {
 	testIgnition(t, `
-	variable "ignition_filesystem_ids" {
+	variable "ignition_filesystem_renders" {
 		type = "list"
 		default = [""]
 	}
@@ -196,8 +196,8 @@ func TestIgnitionConfigFilesystems(t *testing.T) {
 
 	data "ignition_config" "test" {
 		filesystems = concat(
-			[data.ignition_filesystem.test.id],
-			var.ignition_filesystem_ids
+			[data.ignition_filesystem.test.rendered],
+			var.ignition_filesystem_renders
 		)
 	}
 	`, func(c *types.Config) error {
@@ -211,7 +211,7 @@ func TestIgnitionConfigFilesystems(t *testing.T) {
 
 func TestIgnitionConfigFiles(t *testing.T) {
 	testIgnition(t, `
-	variable "ignition_file_ids" {
+	variable "ignition_file_renders" {
 		type = "list"
 		default = [""]
 	}
@@ -226,8 +226,8 @@ func TestIgnitionConfigFiles(t *testing.T) {
 
 	data "ignition_config" "test" {
 		files = concat(
-			[data.ignition_file.test.id],
-			var.ignition_file_ids,
+			[data.ignition_file.test.rendered],
+			var.ignition_file_renders,
 		)
 	}
 	`, func(c *types.Config) error {
@@ -241,7 +241,7 @@ func TestIgnitionConfigFiles(t *testing.T) {
 
 func TestIgnitionConfigSystemd(t *testing.T) {
 	testIgnition(t, `
-	variable "ignition_systemd_ids" {
+	variable "ignition_systemd_renders" {
 		type = "list"
 		default = [""]
 	}
@@ -253,8 +253,8 @@ func TestIgnitionConfigSystemd(t *testing.T) {
 
 	data "ignition_config" "test" {
 		systemd = concat(
-			[data.ignition_systemd_unit.test.id],
-			var.ignition_systemd_ids,
+			[data.ignition_systemd_unit.test.rendered],
+			var.ignition_systemd_renders,
 		)
 	}
 	`, func(c *types.Config) error {
@@ -268,7 +268,7 @@ func TestIgnitionConfigSystemd(t *testing.T) {
 
 func TestIgnitionConfigNetworkd(t *testing.T) {
 	testIgnition(t, `
-	variable "ignition_networkd_ids" {
+	variable "ignition_networkd_renders" {
 		type = "list"
 		default = [""]
 	}
@@ -280,8 +280,8 @@ func TestIgnitionConfigNetworkd(t *testing.T) {
 
 	data "ignition_config" "test" {
 		networkd = concat(
-			[data.ignition_networkd_unit.test.id],
-			var.ignition_networkd_ids
+			[data.ignition_networkd_unit.test.rendered],
+			var.ignition_networkd_renders
 			)
 	}
 	`, func(c *types.Config) error {
@@ -295,7 +295,7 @@ func TestIgnitionConfigNetworkd(t *testing.T) {
 
 func TestIgnitionConfigUsers(t *testing.T) {
 	testIgnition(t, `
-	variable "ignition_user_ids" {
+	variable "ignition_user_renders" {
 		type = "list"
 		default = [""]
 	}
@@ -308,8 +308,8 @@ func TestIgnitionConfigUsers(t *testing.T) {
 
 	data "ignition_config" "test" {
 		users = concat(
-			[data.ignition_user.test.id],
-			var.ignition_user_ids
+			[data.ignition_user.test.rendered],
+			var.ignition_user_renders
 		)
 	}
 	`, func(c *types.Config) error {
@@ -323,7 +323,7 @@ func TestIgnitionConfigUsers(t *testing.T) {
 
 func TestIgnitionConfigGroupss(t *testing.T) {
 	testIgnition(t, `
-	variable "ignition_group_ids" {
+	variable "ignition_group_renders" {
 		type = "list"
 		default = [""]
 	}
@@ -334,8 +334,8 @@ func TestIgnitionConfigGroupss(t *testing.T) {
 
 	data "ignition_config" "test" {
 		groups = concat(
-			[data.ignition_group.test.id],
-			var.ignition_group_ids
+			[data.ignition_group.test.rendered],
+			var.ignition_group_renders
 		)
 	}
 	`, func(c *types.Config) error {

--- a/ignition/resource_ignition_directory_test.go
+++ b/ignition/resource_ignition_directory_test.go
@@ -20,7 +20,7 @@ func TestIngnitionDirectory(t *testing.T) {
 
 		data "ignition_config" "test" {
 			directories = [
-				"${data.ignition_directory.foo.id}",
+				"${data.ignition_directory.foo.rendered}",
 			]
 		}
 	`, func(c *types.Config) error {
@@ -63,7 +63,7 @@ func TestIngnitionDirectoryInvalidMode(t *testing.T) {
 
 		data "ignition_config" "test" {
 			directories = [
-				"${data.ignition_directory.foo.id}",
+				"${data.ignition_directory.foo.rendered}",
 			]
 		}
 	`, regexp.MustCompile("illegal file mode"))
@@ -79,7 +79,7 @@ func TestIngnitionDirectoryInvalidPath(t *testing.T) {
 
 		data "ignition_config" "test" {
 			directories = [
-				"${data.ignition_directory.foo.id}",
+				"${data.ignition_directory.foo.rendered}",
 			]
 		}
 	`, regexp.MustCompile("absolute"))

--- a/ignition/resource_ignition_disk.go
+++ b/ignition/resource_ignition_disk.go
@@ -53,12 +53,12 @@ func dataSourceDisk() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
-						"rendered": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 					},
 				},
+			},
+			"rendered": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/ignition/resource_ignition_disk_test.go
+++ b/ignition/resource_ignition_disk_test.go
@@ -22,7 +22,7 @@ func TestIngnitionDisk(t *testing.T) {
 
 		data "ignition_config" "test" {
 			disks = [
-				"${data.ignition_disk.foo.id}",
+				"${data.ignition_disk.foo.rendered}",
 			]
 		}
 	`, func(c *types.Config) error {
@@ -68,7 +68,7 @@ func TestIngnitionDiskInvalidDevice(t *testing.T) {
 
 		data "ignition_config" "test" {
 			disks = [
-				"${data.ignition_disk.foo.id}",
+				"${data.ignition_disk.foo.rendered}",
 			]
 		}
 	`, regexp.MustCompile("path not absolute"))
@@ -94,7 +94,7 @@ func TestIngnitionDiskInvalidPartition(t *testing.T) {
 
 		data "ignition_config" "test" {
 			disks = [
-				"${data.ignition_disk.foo.id}",
+				"${data.ignition_disk.foo.rendered}",
 			]
 		}
 	`, regexp.MustCompile("overlap"))

--- a/ignition/resource_ignition_file_test.go
+++ b/ignition/resource_ignition_file_test.go
@@ -42,9 +42,9 @@ func TestIngnitionFile(t *testing.T) {
 
 		data "ignition_config" "test" {
 			files = [
-				"${data.ignition_file.foo.id}",
-				"${data.ignition_file.qux.id}",
-				"${data.ignition_file.nop.id}",
+				"${data.ignition_file.foo.rendered}",
+				"${data.ignition_file.qux.rendered}",
+				"${data.ignition_file.nop.rendered}",
 			]
 		}
 	`, func(c *types.Config) error {
@@ -136,7 +136,7 @@ func TestIngnitionFileInvalidMode(t *testing.T) {
 
 		data "ignition_config" "test" {
 			files = [
-				"${data.ignition_file.foo.id}",
+				"${data.ignition_file.foo.rendered}",
 			]
 		}
 	`, regexp.MustCompile("illegal file mode"))
@@ -155,7 +155,7 @@ func TestIngnitionFileInvalidPath(t *testing.T) {
 
 		data "ignition_config" "test" {
 			files = [
-				"${data.ignition_file.foo.id}",
+				"${data.ignition_file.foo.rendered}",
 			]
 		}
 	`, regexp.MustCompile("absolute"))

--- a/ignition/resource_ignition_filesystem_test.go
+++ b/ignition/resource_ignition_filesystem_test.go
@@ -37,9 +37,9 @@ func TestIngnitionFilesystem(t *testing.T) {
 
 		data "ignition_config" "test" {
 			filesystems = [
-				"${data.ignition_filesystem.foo.id}",
-				"${data.ignition_filesystem.qux.id}",
-				"${data.ignition_filesystem.baz.id}",
+				"${data.ignition_filesystem.foo.rendered}",
+				"${data.ignition_filesystem.qux.rendered}",
+				"${data.ignition_filesystem.baz.rendered}",
 			]
 		}
 	`, func(c *types.Config) error {
@@ -119,7 +119,7 @@ func TestIngnitionFilesystemInvalidPath(t *testing.T) {
 
 		data "ignition_config" "test" {
 			filesystems = [
-				"${data.ignition_filesystem.foo.id}",
+				"${data.ignition_filesystem.foo.rendered}",
 			]
 		}
 	`, regexp.MustCompile("absolute"))
@@ -138,7 +138,7 @@ func TestIngnitionFilesystemInvalidPathAndMount(t *testing.T) {
 
 		data "ignition_config" "test" {
 			filesystems = [
-				"${data.ignition_filesystem.foo.id}",
+				"${data.ignition_filesystem.foo.rendered}",
 			]
 		}
 	`, regexp.MustCompile("mount and path"))

--- a/ignition/resource_ignition_group_test.go
+++ b/ignition/resource_ignition_group_test.go
@@ -21,8 +21,8 @@ func TestIngnitionGroup(t *testing.T) {
 
 		data "ignition_config" "test" {
 			groups = [
-				"${data.ignition_group.foo.id}",
-				"${data.ignition_group.qux.id}",
+				"${data.ignition_group.foo.rendered}",
+				"${data.ignition_group.qux.rendered}",
 			]
 		}
 	`, func(c *types.Config) error {

--- a/ignition/resource_ignition_link.go
+++ b/ignition/resource_ignition_link.go
@@ -1,6 +1,8 @@
 package ignition
 
 import (
+	"encoding/json"
+
 	"github.com/coreos/ignition/config/v2_1/types"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -40,12 +42,16 @@ func dataSourceLink() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"rendered": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
 
 func resourceLinkRead(d *schema.ResourceData, meta interface{}) error {
-	id, err := buildLink(d, globalCache)
+	id, err := buildLink(d)
 	if err != nil {
 		return err
 	}
@@ -55,7 +61,7 @@ func resourceLinkRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceLinkExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	id, err := buildLink(d, globalCache)
+	id, err := buildLink(d)
 	if err != nil {
 		return false, err
 	}
@@ -63,7 +69,7 @@ func resourceLinkExists(d *schema.ResourceData, meta interface{}) (bool, error) 
 	return id == d.Id(), nil
 }
 
-func buildLink(d *schema.ResourceData, c *cache) (string, error) {
+func buildLink(d *schema.ResourceData) (string, error) {
 	link := &types.Link{}
 	link.Filesystem = d.Get("filesystem").(string)
 	link.Path = d.Get("path").(string)
@@ -80,5 +86,11 @@ func buildLink(d *schema.ResourceData, c *cache) (string, error) {
 		link.Group = types.NodeGroup{ID: &gid}
 	}
 
-	return c.addLink(link), handleReport(link.Validate())
+	b, err := json.Marshal(link)
+	if err != nil {
+		return "", err
+	}
+	d.Set("rendered", string(b))
+
+	return hash(string(b)), handleReport(link.Validate())
 }

--- a/ignition/resource_ignition_link_test.go
+++ b/ignition/resource_ignition_link_test.go
@@ -21,7 +21,7 @@ func TestIngnitionLink(t *testing.T) {
 
 		data "ignition_config" "test" {
 			links = [
-				"${data.ignition_link.foo.id}",
+				"${data.ignition_link.foo.rendered}",
 			]
 		}
 	`, func(c *types.Config) error {
@@ -68,7 +68,7 @@ func TestIngnitionLinkInvalidPath(t *testing.T) {
 
 		data "ignition_config" "test" {
 			links = [
-				"${data.ignition_link.foo.id}",
+				"${data.ignition_link.foo.rendered}",
 			]
 		}
 	`, regexp.MustCompile("absolute"))

--- a/ignition/resource_ignition_networkd_unit.go
+++ b/ignition/resource_ignition_networkd_unit.go
@@ -40,11 +40,6 @@ func resourceNetworkdUnitRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceNetworkdUnitDelete(d *schema.ResourceData, meta interface{}) error {
-	d.SetId("")
-	return nil
-}
-
 func resourceNetworkdUnitExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	id, err := buildNetworkdUnit(d)
 	if err != nil {

--- a/ignition/resource_ignition_networkd_unit_test.go
+++ b/ignition/resource_ignition_networkd_unit_test.go
@@ -16,7 +16,7 @@ func TestIngnitionNetworkdUnit(t *testing.T) {
 
 		data "ignition_config" "test" {
 			networkd = [
-				"${data.ignition_networkd_unit.foo.id}",
+				"${data.ignition_networkd_unit.foo.rendered}",
 			]
 		}
 	`, func(c *types.Config) error {

--- a/ignition/resource_ignition_raid_test.go
+++ b/ignition/resource_ignition_raid_test.go
@@ -19,7 +19,7 @@ func TestIngnitionRaid(t *testing.T) {
 
 		data "ignition_config" "test" {
 			arrays = [
-				"${data.ignition_raid.foo.id}",
+				"${data.ignition_raid.foo.rendered}",
 			]
 		}
 	`, func(c *types.Config) error {
@@ -59,7 +59,7 @@ func TestIngnitionRaidInvalidLevel(t *testing.T) {
 
 		data "ignition_config" "test" {
 			arrays = [
-				"${data.ignition_raid.foo.id}",
+				"${data.ignition_raid.foo.rendered}",
 			]
 		}
 	`, regexp.MustCompile("raid level"))
@@ -76,7 +76,7 @@ func TestIngnitionRaidInvalidDevices(t *testing.T) {
 
 		data "ignition_config" "test" {
 			arrays = [
-				"${data.ignition_raid.foo.id}",
+				"${data.ignition_raid.foo.rendered}",
 			]
 		}
 	`, regexp.MustCompile("absolute"))

--- a/ignition/resource_ignition_systemd_unit.go
+++ b/ignition/resource_ignition_systemd_unit.go
@@ -1,6 +1,8 @@
 package ignition
 
 import (
+	"encoding/json"
+
 	"github.com/coreos/ignition/config/v2_1/types"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -50,12 +52,16 @@ func dataSourceSystemdUnit() *schema.Resource {
 					},
 				},
 			},
+			"rendered": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
 
 func resourceSystemdUnitRead(d *schema.ResourceData, meta interface{}) error {
-	id, err := buildSystemdUnit(d, globalCache)
+	id, err := buildSystemdUnit(d)
 	if err != nil {
 		return err
 	}
@@ -65,7 +71,7 @@ func resourceSystemdUnitRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceSystemdUnitExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	id, err := buildSystemdUnit(d, globalCache)
+	id, err := buildSystemdUnit(d)
 	if err != nil {
 		return false, err
 	}
@@ -73,7 +79,7 @@ func resourceSystemdUnitExists(d *schema.ResourceData, meta interface{}) (bool, 
 	return id == d.Id(), nil
 }
 
-func buildSystemdUnit(d *schema.ResourceData, c *cache) (string, error) {
+func buildSystemdUnit(d *schema.ResourceData) (string, error) {
 	enabled := d.Get("enabled").(bool)
 	unit := &types.Unit{
 		Name:     d.Get("name").(string),
@@ -105,5 +111,11 @@ func buildSystemdUnit(d *schema.ResourceData, c *cache) (string, error) {
 		unit.Dropins = append(unit.Dropins, d)
 	}
 
-	return c.addSystemdUnit(unit), nil
+	b, err := json.Marshal(unit)
+	if err != nil {
+		return "", err
+	}
+	d.Set("rendered", string(b))
+
+	return hash(string(b)), nil
 }

--- a/ignition/resource_ignition_systemd_unit_test.go
+++ b/ignition/resource_ignition_systemd_unit_test.go
@@ -24,7 +24,7 @@ func TestIngnitionSystemdUnit(t *testing.T) {
 
 		data "ignition_config" "test" {
 			systemd = [
-				"${data.ignition_systemd_unit.foo.id}",
+				"${data.ignition_systemd_unit.foo.rendered}",
 			]
 		}
 	`, func(c *types.Config) error {
@@ -70,7 +70,7 @@ func TestIngnitionSystemdUnitEmptyContentWithDropIn(t *testing.T) {
 
 		data "ignition_config" "test" {
 			systemd = [
-				"${data.ignition_systemd_unit.foo.id}",
+				"${data.ignition_systemd_unit.foo.rendered}",
 			]
 		}
 	`, func(c *types.Config) error {
@@ -106,7 +106,7 @@ func TestIgnitionSystemdUnit_emptyContent(t *testing.T) {
 
 		data "ignition_config" "test" {
 			systemd = [
-				"${data.ignition_systemd_unit.foo.id}",
+				"${data.ignition_systemd_unit.foo.rendered}",
 			]
 		}
 	`, func(c *types.Config) error {
@@ -137,7 +137,7 @@ func TestIngnitionSystemUnitInvalidName(t *testing.T) {
 
 		data "ignition_config" "test" {
 			systemd = [
-				"${data.ignition_systemd_unit.foo.id}",
+				"${data.ignition_systemd_unit.foo.rendered}",
 			]
 		}
 	`, regexp.MustCompile("invalid"))
@@ -153,7 +153,7 @@ func TestIngnitionSystemUnitInvalidContent(t *testing.T) {
 
 		data "ignition_config" "test" {
 			systemd = [
-				"${data.ignition_systemd_unit.foo.id}",
+				"${data.ignition_systemd_unit.foo.rendered}",
 			]
 		}
 	`, regexp.MustCompile("section"))

--- a/ignition/resource_ignition_user.go
+++ b/ignition/resource_ignition_user.go
@@ -1,6 +1,8 @@
 package ignition
 
 import (
+	"encoding/json"
+
 	"github.com/coreos/ignition/config/v2_1/types"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -77,12 +79,16 @@ func dataSourceUser() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"rendered": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
 
 func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
-	id, err := buildUser(d, globalCache)
+	id, err := buildUser(d)
 	if err != nil {
 		return err
 	}
@@ -92,7 +98,7 @@ func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceUserExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	id, err := buildUser(d, globalCache)
+	id, err := buildUser(d)
 	if err != nil {
 		return false, err
 	}
@@ -100,7 +106,7 @@ func resourceUserExists(d *schema.ResourceData, meta interface{}) (bool, error) 
 	return id == d.Id(), nil
 }
 
-func buildUser(d *schema.ResourceData, c *cache) (string, error) {
+func buildUser(d *schema.ResourceData) (string, error) {
 	user := types.PasswdUser{
 		Name:         d.Get("name").(string),
 		UID:          getInt(d, "uid"),
@@ -123,7 +129,13 @@ func buildUser(d *schema.ResourceData, c *cache) (string, error) {
 		user.PasswordHash = &pwd
 	}
 
-	return c.addUser(&user), handleReport(user.Validate())
+	b, err := json.Marshal(user)
+	if err != nil {
+		return "", err
+	}
+	d.Set("rendered", string(b))
+
+	return hash(string(b)), handleReport(user.Validate())
 }
 
 func castSliceInterfaceToPasswdUserGroup(i []interface{}) []types.PasswdUserGroup {

--- a/ignition/resource_ignition_user_test.go
+++ b/ignition/resource_ignition_user_test.go
@@ -31,8 +31,8 @@ func TestIngnitionUser(t *testing.T) {
 
 		data "ignition_config" "test" {
 			users = [
-				"${data.ignition_user.foo.id}",
-				"${data.ignition_user.qux.id}",
+				"${data.ignition_user.foo.rendered}",
+				"${data.ignition_user.qux.rendered}",
 			]
 		}
 	`, func(c *types.Config) error {

--- a/vendor/github.com/pkg/errors/.gitignore
+++ b/vendor/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.x
+  - 1.5.x
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - tip
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors) [![Sourcegraph](https://sourcegraph.com/github.com/pkg/errors/-/badge.svg)](https://sourcegraph.com/github.com/pkg/errors?badge)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## License
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,282 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which when applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// together with the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required, the errors.WithStack and
+// errors.WithMessage functions destructure errors.Wrap into its component
+// operations: annotating an error with a stack trace and with a message,
+// respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error that does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// Although the causer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported:
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively.
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface:
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// The returned errors.StackTrace type is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// Although the stackTracer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is called, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+// WithMessagef annotates err with the format specifier.
+// If err is nil, WithMessagef returns nil.
+func WithMessagef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,147 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -204,6 +204,8 @@ github.com/mitchellh/mapstructure
 github.com/mitchellh/reflectwalk
 # github.com/oklog/run v1.0.0
 github.com/oklog/run
+# github.com/pkg/errors v0.8.1
+github.com/pkg/errors
 # github.com/posener/complete v1.2.1
 github.com/posener/complete
 github.com/posener/complete/cmd/install

--- a/website/docs/d/config.html.md
+++ b/website/docs/d/config.html.md
@@ -15,7 +15,7 @@ Renders an ignition configuration as JSON. It  contains all the disks, partition
 ```hcl
 data "ignition_config" "example" {
 	systemd = [
-		"${data.ignition_systemd_unit.example.id}",
+		data.ignition_systemd_unit.example.rendered,
 	]
 }
 ```

--- a/website/docs/d/directory.html.md
+++ b/website/docs/d/directory.html.md
@@ -37,4 +37,4 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - ID used to reference this resource in _ignition_config_.
+* `rendered` - The rendered template to reference this resource in _ignition_config_.

--- a/website/docs/d/disk.html.md
+++ b/website/docs/d/disk.html.md
@@ -51,4 +51,4 @@ The `partition` block supports:
 
 The following attributes are exported:
 
-* `id` - ID used to reference this resource in _ignition_config_.
+* `rendered` - The rendered template to reference this resource in _ignition_config_.

--- a/website/docs/d/file.html.md
+++ b/website/docs/d/file.html.md
@@ -76,6 +76,6 @@ The `source` block supports:
 
 The following attributes are exported:
 
-* `id` - ID used to reference this resource in _ignition_config_.
+* `rendered` - The rendered template to reference this resource in _ignition_config_.
 
 [rfc2397]: https://tools.ietf.org/html/rfc2397

--- a/website/docs/d/filesystem.html.md
+++ b/website/docs/d/filesystem.html.md
@@ -53,4 +53,4 @@ The `mount` block supports:
 
 The following attributes are exported:
 
-* `id` - ID used to reference this resource in _ignition_config_.
+* `rendered` - The rendered template to reference this resource in _ignition_config_.

--- a/website/docs/d/group.html.md
+++ b/website/docs/d/group.html.md
@@ -32,4 +32,4 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - ID used to reference this resource in _ignition_config_.
+* `rendered` - The rendered template to reference this resource in _ignition_config_.

--- a/website/docs/d/link.html.md
+++ b/website/docs/d/link.html.md
@@ -40,4 +40,4 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - ID used to reference this resource in _ignition_config_.
+* `rendered` - The rendered template to reference this resource in _ignition_config_.

--- a/website/docs/d/networkd_unit.html.md
+++ b/website/docs/d/networkd_unit.html.md
@@ -31,4 +31,4 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - ID used to reference this resource in _ignition_config_.
+* `rendered` - The rendered template to reference this resource in _ignition_config_.g_.

--- a/website/docs/d/networkd_unit.html.md
+++ b/website/docs/d/networkd_unit.html.md
@@ -31,4 +31,4 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `rendered` - The rendered template to reference this resource in _ignition_config_.g_.
+* `rendered` - The rendered template to reference this resource in _ignition_config_.

--- a/website/docs/d/raid.html.md
+++ b/website/docs/d/raid.html.md
@@ -61,4 +61,4 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - ID used to reference this resource in _ignition_config_
+* `rendered` - The rendered template to reference this resource in _ignition_config_.

--- a/website/docs/d/systemd_unit.html.md
+++ b/website/docs/d/systemd_unit.html.md
@@ -43,4 +43,4 @@ The `dropin` block supports:
 
 The following attributes are exported:
 
-* `id` - ID used to reference this resource in _ignition_config_.
+* `rendered` - The rendered template to reference this resource in _ignition_config_.

--- a/website/docs/d/user.html.md
+++ b/website/docs/d/user.html.md
@@ -54,4 +54,4 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - ID used to reference this resource in _ignition_config_.
+* `rendered` - The rendered template to reference this resource in _ignition_config_.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -43,6 +43,6 @@ data "ignition_config" "example" {
 resource "aws_instance" "web" {
   # ...
 
-  user_data = data.ignition_config.example.rendered"
+  user_data = data.ignition_config.example.rendered
 }
 ```

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -35,7 +35,7 @@ data "ignition_systemd_unit" "example" {
 # Ingnition config include the previous defined systemd unit data resource
 data "ignition_config" "example" {
   systemd = [
-    "${data.ignition_systemd_unit.example.id}",
+    data.ignition_systemd_unit.example.rendered,
   ]
 }
 
@@ -43,6 +43,6 @@ data "ignition_config" "example" {
 resource "aws_instance" "web" {
   # ...
 
-  user_data = "${data.ignition_config.example.rendered}"
+  user_data = data.ignition_config.example.rendered"
 }
 ```


### PR DESCRIPTION
This removes the internal cache system by passing JSON strings as
rendered property to the data resource. This gets passed to
ignition_config instead of the ID.
This uses the Terraform state as cache instead of the old in memory module.

This change is breaking as it will need to have all ID references replaced.

Signed-off-by: Maartje Eyskens <maartje@eyskens.me>