### PR TITLE
Fix documentation as file and directory mode have same behaviour

### DIFF
--- a/website/docs/d/directory.html.md
+++ b/website/docs/d/directory.html.md
@@ -27,7 +27,7 @@ The following arguments are supported:
 
 * `path` - (Required) The absolute path to the directory.
 
-* `mode` - (Optional) The directory's permission mode. Note that the mode can be specified as a decimal value (i.e. 0755 -> 493) or an octal value(i.e 0755).
+* `mode` - (Optional) The directory's permission mode. Note that the mode can be specified as either an octal value (e.g 0755) or a decimal value (i.e. 493 as equivalent to the octal 0755).
 
 * `uid` - (Optional) The user ID of the owner.
 

--- a/website/docs/d/file.html.md
+++ b/website/docs/d/file.html.md
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 	__Note__: `content` and `source` are mutually exclusive.
 
-* `mode` - (Optional) The file's permission mode. The mode must be properly specified as a decimal value (i.e. 0644 -> 420).
+* `mode` - (Optional) The file's permission mode. Note that the mode can be specified as either an octal value (e.g 0755) or a decimal value (i.e. 493 as equivalent to the octal 0755).
 
 * `uid` - (Optional) The user ID of the owner.
 


### PR DESCRIPTION
Small changes to add extra space for better readability

Unless I am completely mistaken, both directory and file now supports mode being expressed as octal string. At least if was working perfectly well with octal modes in my last series of tests