### PR TITLE
Correct spelling in test names

### DIFF
--- a/ignition/resource_ignition_config_test.go
+++ b/ignition/resource_ignition_config_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestIngnitionFileReplace(t *testing.T) {
+func TestIgnitionFileReplace(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_config" "test" {
 			replace {
@@ -37,7 +37,7 @@ func TestIngnitionFileReplace(t *testing.T) {
 	})
 }
 
-func TestIngnitionFileAppend(t *testing.T) {
+func TestIgnitionFileAppend(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_config" "test" {
 			append {
@@ -68,7 +68,7 @@ func TestIngnitionFileAppend(t *testing.T) {
 	})
 }
 
-func TestIngnitionFileReplaceNoVerification(t *testing.T) {
+func TestIgnitionFileReplaceNoVerification(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_config" "test" {
 			replace {
@@ -93,7 +93,7 @@ func TestIngnitionFileReplaceNoVerification(t *testing.T) {
 	})
 }
 
-func TestIngnitionFileAppendNoVerification(t *testing.T) {
+func TestIgnitionFileAppendNoVerification(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_config" "test" {
 			append {

--- a/ignition/resource_ignition_directory_test.go
+++ b/ignition/resource_ignition_directory_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/coreos/ignition/config/v2_1/types"
 )
 
-func TestIngnitionDirectory(t *testing.T) {
+func TestIgnitionDirectory(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_directory" "foo" {
 			filesystem = "foo"
@@ -53,7 +53,7 @@ func TestIngnitionDirectory(t *testing.T) {
 	})
 }
 
-func TestIngnitionDirectoryInvalidMode(t *testing.T) {
+func TestIgnitionDirectoryInvalidMode(t *testing.T) {
 	testIgnitionError(t, `
 		data "ignition_directory" "foo" {
 			filesystem = "foo"
@@ -69,7 +69,7 @@ func TestIngnitionDirectoryInvalidMode(t *testing.T) {
 	`, regexp.MustCompile("illegal file mode"))
 }
 
-func TestIngnitionDirectoryInvalidPath(t *testing.T) {
+func TestIgnitionDirectoryInvalidPath(t *testing.T) {
 	testIgnitionError(t, `
 		data "ignition_directory" "foo" {
 			filesystem = "foo"

--- a/ignition/resource_ignition_disk_test.go
+++ b/ignition/resource_ignition_disk_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/coreos/ignition/config/v2_1/types"
 )
 
-func TestIngnitionDisk(t *testing.T) {
+func TestIgnitionDisk(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_disk" "foo" {
 			device = "/foo"
@@ -60,7 +60,7 @@ func TestIngnitionDisk(t *testing.T) {
 	})
 }
 
-func TestIngnitionDiskInvalidDevice(t *testing.T) {
+func TestIgnitionDiskInvalidDevice(t *testing.T) {
 	testIgnitionError(t, `
 		data "ignition_disk" "foo" {
 			device = "a"
@@ -74,7 +74,7 @@ func TestIngnitionDiskInvalidDevice(t *testing.T) {
 	`, regexp.MustCompile("path not absolute"))
 }
 
-func TestIngnitionDiskInvalidPartition(t *testing.T) {
+func TestIgnitionDiskInvalidPartition(t *testing.T) {
 	testIgnitionError(t, `
 		data "ignition_disk" "foo" {
 			device = "/foo"

--- a/ignition/resource_ignition_file_test.go
+++ b/ignition/resource_ignition_file_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/coreos/ignition/config/v2_1/types"
 )
 
-func TestIngnitionFile(t *testing.T) {
+func TestIgnitionFile(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_file" "foo" {
 			filesystem = "foo"
@@ -123,7 +123,7 @@ func TestIngnitionFile(t *testing.T) {
 	})
 }
 
-func TestIngnitionFileInvalidMode(t *testing.T) {
+func TestIgnitionFileInvalidMode(t *testing.T) {
 	testIgnitionError(t, `
 		data "ignition_file" "foo" {
 			filesystem = "foo"
@@ -142,7 +142,7 @@ func TestIngnitionFileInvalidMode(t *testing.T) {
 	`, regexp.MustCompile("illegal file mode"))
 }
 
-func TestIngnitionFileInvalidPath(t *testing.T) {
+func TestIgnitionFileInvalidPath(t *testing.T) {
 	testIgnitionError(t, `
 		data "ignition_file" "foo" {
 			filesystem = "foo"

--- a/ignition/resource_ignition_filesystem_test.go
+++ b/ignition/resource_ignition_filesystem_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/coreos/ignition/config/v2_1/types"
 )
 
-func TestIngnitionFilesystem(t *testing.T) {
+func TestIgnitionFilesystem(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_filesystem" "foo" {
 			name = "foo"
@@ -110,7 +110,7 @@ func TestIngnitionFilesystem(t *testing.T) {
 	})
 }
 
-func TestIngnitionFilesystemInvalidPath(t *testing.T) {
+func TestIgnitionFilesystemInvalidPath(t *testing.T) {
 	testIgnitionError(t, `
 		data "ignition_filesystem" "foo" {
 			name = "foo"
@@ -125,7 +125,7 @@ func TestIngnitionFilesystemInvalidPath(t *testing.T) {
 	`, regexp.MustCompile("absolute"))
 }
 
-func TestIngnitionFilesystemInvalidPathAndMount(t *testing.T) {
+func TestIgnitionFilesystemInvalidPathAndMount(t *testing.T) {
 	testIgnitionError(t, `
 		data "ignition_filesystem" "foo" {
 			name = "foo"

--- a/ignition/resource_ignition_group_test.go
+++ b/ignition/resource_ignition_group_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/coreos/ignition/config/v2_1/types"
 )
 
-func TestIngnitionGroup(t *testing.T) {
+func TestIgnitionGroup(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_group" "foo" {
 			name = "foo"

--- a/ignition/resource_ignition_link_test.go
+++ b/ignition/resource_ignition_link_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/coreos/ignition/config/v2_1/types"
 )
 
-func TestIngnitionLink(t *testing.T) {
+func TestIgnitionLink(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_link" "foo" {
 			filesystem = "foo"
@@ -58,7 +58,7 @@ func TestIngnitionLink(t *testing.T) {
 	})
 }
 
-func TestIngnitionLinkInvalidPath(t *testing.T) {
+func TestIgnitionLinkInvalidPath(t *testing.T) {
 	testIgnitionError(t, `
 		data "ignition_link" "foo" {
 			filesystem = "foo"

--- a/ignition/resource_ignition_networkd_unit_test.go
+++ b/ignition/resource_ignition_networkd_unit_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/coreos/ignition/config/v2_1/types"
 )
 
-func TestIngnitionNetworkdUnit(t *testing.T) {
+func TestIgnitionNetworkdUnit(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_networkd_unit" "foo" {
 			name = "foo.link"

--- a/ignition/resource_ignition_raid_test.go
+++ b/ignition/resource_ignition_raid_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/coreos/ignition/config/v2_1/types"
 )
 
-func TestIngnitionRaid(t *testing.T) {
+func TestIgnitionRaid(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_raid" "foo" {
 			name = "foo"
@@ -48,7 +48,7 @@ func TestIngnitionRaid(t *testing.T) {
 	})
 }
 
-func TestIngnitionRaidInvalidLevel(t *testing.T) {
+func TestIgnitionRaidInvalidLevel(t *testing.T) {
 	testIgnitionError(t, `
 		data "ignition_raid" "foo" {
 			name = "foo"
@@ -65,7 +65,7 @@ func TestIngnitionRaidInvalidLevel(t *testing.T) {
 	`, regexp.MustCompile("raid level"))
 }
 
-func TestIngnitionRaidInvalidDevices(t *testing.T) {
+func TestIgnitionRaidInvalidDevices(t *testing.T) {
 	testIgnitionError(t, `
 		data "ignition_raid" "foo" {
 			name = "foo"

--- a/ignition/resource_ignition_systemd_unit_test.go
+++ b/ignition/resource_ignition_systemd_unit_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/coreos/ignition/config/v2_1/types"
 )
 
-func TestIngnitionSystemdUnit(t *testing.T) {
+func TestIgnitionSystemdUnit(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_systemd_unit" "foo" {
 			name = "foo.service"
@@ -58,7 +58,7 @@ func TestIngnitionSystemdUnit(t *testing.T) {
 	})
 }
 
-func TestIngnitionSystemdUnitEmptyContentWithDropIn(t *testing.T) {
+func TestIgnitionSystemdUnitEmptyContentWithDropIn(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_systemd_unit" "foo" {
 			name = "foo.service"
@@ -128,7 +128,7 @@ func TestIgnitionSystemdUnit_emptyContent(t *testing.T) {
 	})
 }
 
-func TestIngnitionSystemUnitInvalidName(t *testing.T) {
+func TestIgnitionSystemUnitInvalidName(t *testing.T) {
 	testIgnitionError(t, `
 		data "ignition_systemd_unit" "foo" {
 			name = "foo"
@@ -143,7 +143,7 @@ func TestIngnitionSystemUnitInvalidName(t *testing.T) {
 	`, regexp.MustCompile("invalid"))
 }
 
-func TestIngnitionSystemUnitInvalidContent(t *testing.T) {
+func TestIgnitionSystemUnitInvalidContent(t *testing.T) {
 	testIgnitionError(t, `
 		data "ignition_systemd_unit" "foo" {
 			name = "foo.service"

--- a/ignition/resource_ignition_user_test.go
+++ b/ignition/resource_ignition_user_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/coreos/ignition/config/v2_1/types"
 )
 
-func TestIngnitionUser(t *testing.T) {
+func TestIgnitionUser(t *testing.T) {
 	testIgnition(t, `
 		data "ignition_user" "foo" {
 			name = "foo"


### PR DESCRIPTION
```
» make testacc                                                                                                    alex@MacBook-Pro-2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?       github.com/terraform-providers/terraform-provider-ignition      [no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestIgnitionFileReplace
--- PASS: TestIgnitionFileReplace (0.04s)
=== RUN   TestIgnitionFileAppend
--- PASS: TestIgnitionFileAppend (0.04s)
=== RUN   TestIgnitionFileReplaceNoVerification
--- PASS: TestIgnitionFileReplaceNoVerification (0.03s)
=== RUN   TestIgnitionFileAppendNoVerification
--- PASS: TestIgnitionFileAppendNoVerification (0.03s)
=== RUN   TestIgnitionConfigDisks
--- PASS: TestIgnitionConfigDisks (0.04s)
=== RUN   TestIgnitionConfigArrays
--- PASS: TestIgnitionConfigArrays (0.04s)
=== RUN   TestIgnitionConfigFilesystems
--- PASS: TestIgnitionConfigFilesystems (0.04s)
=== RUN   TestIgnitionConfigFiles
--- PASS: TestIgnitionConfigFiles (0.04s)
=== RUN   TestIgnitionConfigSystemd
--- PASS: TestIgnitionConfigSystemd (0.04s)
=== RUN   TestIgnitionConfigNetworkd
--- PASS: TestIgnitionConfigNetworkd (0.04s)
=== RUN   TestIgnitionConfigUsers
--- PASS: TestIgnitionConfigUsers (0.04s)
=== RUN   TestIgnitionConfigGroupss
--- PASS: TestIgnitionConfigGroupss (0.03s)
=== RUN   TestIgnitionDirectory
--- PASS: TestIgnitionDirectory (0.03s)
=== RUN   TestIgnitionDirectoryInvalidMode
--- PASS: TestIgnitionDirectoryInvalidMode (0.01s)
=== RUN   TestIgnitionDirectoryInvalidPath
--- PASS: TestIgnitionDirectoryInvalidPath (0.01s)
=== RUN   TestIgnitionDisk
--- PASS: TestIgnitionDisk (0.04s)
=== RUN   TestIgnitionDiskInvalidDevice
--- PASS: TestIgnitionDiskInvalidDevice (0.01s)
=== RUN   TestIgnitionDiskInvalidPartition
--- PASS: TestIgnitionDiskInvalidPartition (0.01s)
=== RUN   TestIgnitionFile
--- PASS: TestIgnitionFile (0.05s)
=== RUN   TestIgnitionFileInvalidMode
--- PASS: TestIgnitionFileInvalidMode (0.01s)
=== RUN   TestIgnitionFileInvalidPath
--- PASS: TestIgnitionFileInvalidPath (0.01s)
=== RUN   TestIgnitionFilesystem
--- PASS: TestIgnitionFilesystem (0.05s)
=== RUN   TestIgnitionFilesystemInvalidPath
--- PASS: TestIgnitionFilesystemInvalidPath (0.01s)
=== RUN   TestIgnitionFilesystemInvalidPathAndMount
--- PASS: TestIgnitionFilesystemInvalidPathAndMount (0.01s)
=== RUN   TestIgnitionGroup
--- PASS: TestIgnitionGroup (0.05s)
=== RUN   TestIgnitionLink
--- PASS: TestIgnitionLink (0.04s)
=== RUN   TestIgnitionLinkInvalidPath
--- PASS: TestIgnitionLinkInvalidPath (0.01s)
=== RUN   TestIgnitionNetworkdUnit
--- PASS: TestIgnitionNetworkdUnit (0.04s)
=== RUN   TestIgnitionRaid
--- PASS: TestIgnitionRaid (0.04s)
=== RUN   TestIgnitionRaidInvalidLevel
--- PASS: TestIgnitionRaidInvalidLevel (0.01s)
=== RUN   TestIgnitionRaidInvalidDevices
--- PASS: TestIgnitionRaidInvalidDevices (0.01s)
=== RUN   TestIgnitionSystemdUnit
--- PASS: TestIgnitionSystemdUnit (0.04s)
=== RUN   TestIgnitionSystemdUnitEmptyContentWithDropIn
--- PASS: TestIgnitionSystemdUnitEmptyContentWithDropIn (0.03s)
=== RUN   TestIgnitionSystemdUnit_emptyContent
--- PASS: TestIgnitionSystemdUnit_emptyContent (0.03s)
=== RUN   TestIgnitionSystemUnitInvalidName
--- PASS: TestIgnitionSystemUnitInvalidName (0.01s)
=== RUN   TestIgnitionSystemUnitInvalidContent
--- PASS: TestIgnitionSystemUnitInvalidContent (0.01s)
=== RUN   TestIgnitionUser
--- PASS: TestIgnitionUser (0.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-ignition/ignition     2.876s
------------------------------------------------------------
```